### PR TITLE
Add gitattributes with configuration for zip files

### DIFF
--- a/.gitattributes
+++ b/.gitattributes
@@ -1,0 +1,1 @@
+*.zip filter=lfs diff=lfs merge=lfs -text


### PR DESCRIPTION
### What
We'll add the engine binary .zip here, so update the git lfs configuration for zip.

### Testing
None, but seems fine.