### PR TITLE
Add copyright to license

### DIFF
--- a/LICENSE
+++ b/LICENSE
@@ -1,3 +1,5 @@
+Copyright © 2026 Niantic Spatial, Inc. All rights reserved.
+
 XR ENGINE LICENSE AGREEMENT
 
 This XR Engine License Agreement (the “Agreement”) should be read carefully before using the XR engine, as may

--- a/xr-standalone.zip
+++ b/xr-standalone.zip
@@ -1,3 +1,3 @@
 version https://git-lfs.github.com/spec/v1
-oid sha256:08259fd998aa1091cd7d543d9fe69b9bc8c0d802bf3ab93f100510c15c238395
-size 13998893
+oid sha256:a2fc73ba450c1a96ee2a20db442f7fb328a3c8b76565e7e9d15b68cd75c86a93
+size 13998848


### PR DESCRIPTION
## Context

This new build of the engine includes the copyright notice in the LICENSE text, as well as in the file headers. This should make it easier to conform to the attribution requirements.