### PR TITLE
Add npm configuration

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,2 +1,3 @@
 # Mac OS
 **/.DS_Store
+tmp

--- a/README.md
+++ b/README.md
@@ -3,11 +3,43 @@
 > [!IMPORTANT]
 > This is not the MIT-licensed open source 8th Wall engine. That is in a separate repository which can be found [here](https://github.com/8thwall/8thwall/blob/main/packages/engine/README.md).
 
+## Usage
+
+See https://8thwall.org/docs/engine/overview for more detailed information.
+
+### Option 1: Script tag
+
+```html
+<script async src=" https://cdn.jsdelivr.net/npm/@8thwall/engine-binary@1/dist/xr.js" data-preload-chunks="slam"></script>
+```
+
+### Option 2: npm
+
+```
+npm install @8thwall/engine-binary
+```
+
+When installed through npm, you will copy the artifacts into your published project, for example in webpack:
+
+```js
+// Example webpack configuration
+new CopyWebpackPlugin({
+  patterns: [
+    {
+      from: 'node_modules/@8thwall/engine-binary/dist',
+      to: 'external/xr',
+    }
+  ]
+})
+```
+
+```html
+<script async src="./external/xr/xr.js" data-preload-chunks="slam"></script>
+```
+
 ## Overview
 
-This repo holds the distributed 8th Wall engine binary.
-
-The 8th Wall engine binary contains the core 8th Wall AR engine and is included with each project exported using Buildable Code Export.
+The 8th Wall engine binary contains the core 8th Wall AR engine
 
 It is provided as closed source and governed by a limited-use distribution license.
 
@@ -26,15 +58,6 @@ The 8th Wall engine binary does not include:
 - Niantic Spatial products such as VPS, Lightship Maps, or the Geospatial Browser
 - Hand Tracking
 
-## Usage
+## Acceptable Use and License
 
-See https://8th.io/getting-started for an integration guide.
-
-## Resources
-
-Read more about this release and how to migrate your projects to the 8th Wall engine binary here:
-
-- [Self-hosted Project Migration Guide](https://www.8thwall.com/docs/migration/self-hosted/)
-- [Distributed 8th Wall Engine Binary](https://8thwall.com/docs/migration/faq/#distributed-8th-wall-engine-binary)
-- [Distributed Engine Binary License and Permitted Use](https://www.8thwall.com/docs/migration/faq/#distributed-engine-binary-license-and-permitted-use)
-- [8th Wall Transition Update: Engine Distribution and Open Source Plans](https://www.8thwall.com/blog/post/202888018234/8th-wall-update-engine-distribution-and-open-source-plans)
+The Distributed Engine Binary is available through a limited-use license which places restrictions on how it can be used. The full license text is [here](https://github.com/8thwall/engine/blob/main/LICENSE). Please see the [Permitted Use FAQ](https://8thwall.org/docs/migration/faq#distributed-engine-binary-license-and-permitted-use) and [Attribution Guidelines](https://8thwall.org/docs/open-source) for more information.

--- a/README.md
+++ b/README.md
@@ -5,12 +5,12 @@
 
 ## Usage
 
-See https://8thwall.org/docs/engine/overview for more detailed information.
+See https://8thwall.org/docs/engine/overview for a more detailed guide.
 
 ### Option 1: Script tag
 
 ```html
-<script async src=" https://cdn.jsdelivr.net/npm/@8thwall/engine-binary@1/dist/xr.js" data-preload-chunks="slam"></script>
+<script src="https://cdn.jsdelivr.net/npm/@8thwall/engine-binary@1/dist/xr.js" async crossorigin="anonymous" data-preload-chunks="slam"></script>
 ```
 
 ### Option 2: npm
@@ -19,10 +19,9 @@ See https://8thwall.org/docs/engine/overview for more detailed information.
 npm install @8thwall/engine-binary
 ```
 
-When installed through npm, you will copy the artifacts into your published project, for example in webpack:
+You will need to copy the included artifacts into your dist folder, for example in webpack:
 
 ```js
-// Example webpack configuration
 new CopyWebpackPlugin({
   patterns: [
     {
@@ -33,15 +32,21 @@ new CopyWebpackPlugin({
 })
 ```
 
+You can then load the SDK by adding the following to index.html:
+
 ```html
-<script async src="./external/xr/xr.js" data-preload-chunks="slam"></script>
+<script src="./external/xr/xr.js" async data-preload-chunks="slam"></script>
+```
+
+When importing the package, you will get a simple helper for accessing XR8 once it is loaded. This promise will only resolve if the script tag is included in the HTML.
+
+```js
+import {XR8Promise} from '@8thwall/engine-binary'
+
+XR8Promise.then((XR8) => XR8.XrController.configure({}))
 ```
 
 ## Overview
-
-The 8th Wall engine binary contains the core 8th Wall AR engine
-
-It is provided as closed source and governed by a limited-use distribution license.
 
 The 8th Wall engine binary includes the core AR capabilities that power 8th Wall experiences, including:
 

--- a/RELEASING.md
+++ b/RELEASING.md
@@ -1,0 +1,16 @@
+# Releasing
+
+## Publishing a pre-release build
+
+1. Update the package.json version to the expected version number
+2. `./tools/prepare.sh`
+2. `cd tmp`
+3. `npm publish --tag alpha --access public`
+
+## Publishing a production build
+
+1. Update the package.json version to indicate the changes made since last release, following Semver. Make sure the version does not have a build suffix.
+2. `./tools/prepare.sh`
+2. `cd tmp`
+3. `npm publish --tag latest --access public --dry-run`
+4. If the preview looks good, run again without `--dry-run`

--- a/package.json
+++ b/package.json
@@ -1,0 +1,33 @@
+{
+  "name": "@8thwall/engine-binary",
+  "version": "1.0.0",
+  "description": "Framework for cross platform, browser based AR",
+  "author": "8th Wall Team",
+  "license": "See LICENSE",
+  "homepage": "https://8thwall.org",
+  "bugs": {
+    "url": "https://github.com/8thwall/8thwall/issues"
+  },
+  "repository": {
+    "type": "git",
+    "url": "git+https://github.com/8thwall/engine.git"
+  },
+  "keywords": [
+    "8thwall",
+    "ar",
+    "xr",
+    "augmented reality",
+    "world tracking",
+    "image tracking",
+    "face tracking",
+    "slam",
+    "webxr"
+  ],
+  "main": "index.js",
+  "files": [
+    "dist",
+    "index.js",
+    "LICENSE",
+    "README.md"
+  ]
+}

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@8thwall/engine-binary",
-  "version": "1.0.0-alpha.3",
+  "version": "1.0.0",
   "description": "Framework for cross platform, browser based AR",
   "author": "8th Wall Team",
   "license": "See LICENSE",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@8thwall/engine-binary",
-  "version": "1.0.0",
+  "version": "1.0.0-alpha.2",
   "description": "Framework for cross platform, browser based AR",
   "author": "8th Wall Team",
   "license": "See LICENSE",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@8thwall/engine-binary",
-  "version": "1.0.0-alpha.2",
+  "version": "1.0.0-alpha.3",
   "description": "Framework for cross platform, browser based AR",
   "author": "8th Wall Team",
   "license": "See LICENSE",

--- a/tools/entry.js
+++ b/tools/entry.js
@@ -1,0 +1,11 @@
+const XR8Promise = new Promise((resolve) => {
+  if (window.XR8) {
+    resolve(window.XR8)
+  } else {
+    window.addEventListener('xrloaded', () => resolve(window.XR8), {once: true})
+  }
+})
+
+module.exports = {
+  XR8Promise,
+}

--- a/tools/prepare.sh
+++ b/tools/prepare.sh
@@ -1,0 +1,29 @@
+#!/bin/bash
+set -e
+
+rm -rf tmp
+mkdir tmp
+cp package.json LICENSE xr-standalone.zip README.md tmp
+
+# Put the following file to disk
+cat <<EOF > tmp/index.js
+const XR8 = () => new Promise((resolve) => {
+  if (window.XR8) {
+    resolve(window.XR8)
+  } else {
+    window.addEventListener('xrloaded', () => resolve(window.XR8), {once: true})
+  }
+})
+
+const XR8 = await
+module.exports = {
+  xr8Ready,
+}
+EOF
+
+mkdir tmp/dist
+
+cd tmp/dist
+
+unzip ../xr-standalone.zip
+

--- a/tools/prepare.sh
+++ b/tools/prepare.sh
@@ -5,7 +5,5 @@ rm -rf tmp
 mkdir -p tmp/dist
 cp package.json LICENSE xr-standalone.zip README.md tmp
 cp tools/entry.js tmp/index.js
-
 cd tmp/dist
 unzip ../xr-standalone.zip
-

--- a/tools/prepare.sh
+++ b/tools/prepare.sh
@@ -2,28 +2,10 @@
 set -e
 
 rm -rf tmp
-mkdir tmp
+mkdir -p tmp/dist
 cp package.json LICENSE xr-standalone.zip README.md tmp
-
-# Put the following file to disk
-cat <<EOF > tmp/index.js
-const XR8 = () => new Promise((resolve) => {
-  if (window.XR8) {
-    resolve(window.XR8)
-  } else {
-    window.addEventListener('xrloaded', () => resolve(window.XR8), {once: true})
-  }
-})
-
-const XR8 = await
-module.exports = {
-  xr8Ready,
-}
-EOF
-
-mkdir tmp/dist
+cp tools/entry.js tmp/index.js
 
 cd tmp/dist
-
 unzip ../xr-standalone.zip
 


### PR DESCRIPTION
## Context

This enables users to install the engine through npm, or use it through jsdelivr.

## Testing

- Tested with https://cdn.jsdelivr.net/npm/@8thwall/engine-binary@1.0.0-alpha.3/dist/xr.js, which worked
- `npm install @8thwall/engine-binary@1.0.0-alpha.3` works and can include the artifacts in the build